### PR TITLE
Added expected results table to gridappsd_mysql_dump.sql

### DIFF
--- a/gridappsd_mysql_dump.sql
+++ b/gridappsd_mysql_dump.sql
@@ -27,3 +27,19 @@ CREATE TABLE `log` (
   `username` varchar(20) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=22 DEFAULT CHARSET=utf8 COMMENT='This table contain log messages and status from variaous processes in gridappsd platform.';
+
+--
+-- Table structure for table `expected_results`
+--
+DROP TABLE IF EXISTS `expected_results`;
+CREATE TABLE `expected_results` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `test_id` varchar(255) DEFAULT NULL,
+  `process_id` varchar(255) DEFAULT NULL,
+  `mrid` varchar(255) NOT NULL,
+  `property` varchar(255) NOT NULL,
+  `expected` varchar(255) NOT NULL,
+  `actual` varchar(255)  NOT NULL,
+  `simulation_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=22 DEFAULT CHARSET=utf8 COMMENT='This table contains the messages for the expected results';


### PR DESCRIPTION
Added expected results table to gridappsd_mysql_dump.sql

Tied to issue 397
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/GRIDAPPSD/Bootstrap/pull/2%23issuecomment-400431151%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/GRIDAPPSD/Bootstrap/pull/2%23issuecomment-400431151%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hello%2C%5Cr%5CnIt%20should%20reflect%20the%20simulation%20time.%20At%20the%20moment%20I%20am%20sending%20the%20current%20time.%20I%20think%20it%20might%20be%20best%20to%20have%20both%20times%20in%20the%20table%20though.%20%20I%20don%5Cu2019t%20think%20we%20are%20sending%20the%20simulation%20time%20at%20the%20moment.%5Cr%5CnThanks%2C%5Cr%5Cn-Jeff%5Cr%5Cn%5Cr%5CnFrom%3A%20tonya1%20%3Cnotifications%40github.com%3E%5Cr%5CnReply-To%3A%20GRIDAPPSD/Bootstrap%20%3Creply%40reply.github.com%3E%5Cr%5CnDate%3A%20Tuesday%2C%20June%2026%2C%202018%20at%2011%3A41%20AM%5Cr%5CnTo%3A%20GRIDAPPSD/Bootstrap%20%3CBootstrap%40noreply.github.com%3E%5Cr%5CnCc%3A%20%5C%22Simpson%2C%20Jeff%5C%22%20%3CJeff.Simpson%40nrel.gov%3E%2C%20Author%20%3Cauthor%40noreply.github.com%3E%5Cr%5CnSubject%3A%20Re%3A%20%5BGRIDAPPSD/Bootstrap%5D%20Added%20expected%20results%20table%20to%20gridappsd_mysql_dump.sql%20%28%232%29%5Cr%5Cn%5Cr%5Cn%5Cr%5Cn%40tonya1%20commented%20on%20this%20pull%20request.%5Cr%5Cn%5Cr%5CnShould%20the%20simulation_time%20change%20to%20the%20current%20time%20if%20the%20record%20is%20updated%3F%5Cr%5Cn%5Cr%5Cn%5Cu2014%5Cr%5CnYou%20are%20receiving%20this%20because%20you%20authored%20the%20thread.%5Cr%5CnReply%20to%20this%20email%20directly%2C%20view%20it%20on%20GitHub%3Chttps%3A//na01.safelinks.protection.outlook.com/%3Furl%3Dhttps%253A%252F%252Fgithub.com%252FGRIDAPPSD%252FBootstrap%252Fpull%252F2%2523pullrequestreview-132131844%26data%3D02%257C01%257CJeff.Simpson%2540nrel.gov%257C4801206439134c5094a608d5db8c01f7%257Ca0f29d7e28cd4f5484427885aee7c080%257C0%257C0%257C636656316743938556%26sdata%3DHYEC8NFeC8XfC19NnUECbqQ4LpQogW2a%252FNmUr%252FSZbQw%253D%26reserved%3D0%3E%2C%20or%20mute%20the%20thread%3Chttps%3A//na01.safelinks.protection.outlook.com/%3Furl%3Dhttps%253A%252F%252Fgithub.com%252Fnotifications%252Funsubscribe-auth%252FAWR_WKIdkTN-aVT-5M602bJPRnfCG2wGks5uAnI2gaJpZM4UyuqH%26data%3D02%257C01%257CJeff.Simpson%2540nrel.gov%257C4801206439134c5094a608d5db8c01f7%257Ca0f29d7e28cd4f5484427885aee7c080%257C0%257C0%257C636656316743948560%26sdata%3DoJnBrmRVTL7UfYgykEj976L72rnTaj50Z1tuNa4VNfo%253D%26reserved%3D0%3E.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222018-06-26T19%3A17%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/23363416%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Jeffrey-Simpson%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/GRIDAPPSD/Bootstrap/pull/2#issuecomment-400431151'>General Comment</a></b>
- <a href='https://github.com/Jeffrey-Simpson'><img border=0 src='https://avatars2.githubusercontent.com/u/23363416?v=4' height=16 width=16></a> Hello,
It should reflect the simulation time. At the moment I am sending the current time. I think it might be best to have both times in the table though.  I don’t think we are sending the simulation time at the moment.
Thanks,
-Jeff
From: tonya1 <notifications@github.com>
Reply-To: GRIDAPPSD/Bootstrap <reply@reply.github.com>
Date: Tuesday, June 26, 2018 at 11:41 AM
To: GRIDAPPSD/Bootstrap <Bootstrap@noreply.github.com>
Cc: "Simpson, Jeff" <Jeff.Simpson@nrel.gov>, Author <author@noreply.github.com>
Subject: Re: [GRIDAPPSD/Bootstrap] Added expected results table to gridappsd_mysql_dump.sql (#2)
@tonya1 commented on this pull request.
Should the simulation_time change to the current time if the record is updated?
—
You are receiving this because you authored the thread.
Reply to this email directly, view it on GitHub<https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FGRIDAPPSD%2FBootstrap%2Fpull%2F2%23pullrequestreview-132131844&data=02%7C01%7CJeff.Simpson%40nrel.gov%7C4801206439134c5094a608d5db8c01f7%7Ca0f29d7e28cd4f5484427885aee7c080%7C0%7C0%7C636656316743938556&sdata=HYEC8NFeC8XfC19NnUECbqQ4LpQogW2a%2FNmUr%2FSZbQw%3D&reserved=0>, or mute the thread<https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fnotifications%2Funsubscribe-auth%2FAWR_WKIdkTN-aVT-5M602bJPRnfCG2wGks5uAnI2gaJpZM4UyuqH&data=02%7C01%7CJeff.Simpson%40nrel.gov%7C4801206439134c5094a608d5db8c01f7%7Ca0f29d7e28cd4f5484427885aee7c080%7C0%7C0%7C636656316743948560&sdata=oJnBrmRVTL7UfYgykEj976L72rnTaj50Z1tuNa4VNfo%3D&reserved=0>.


<a href='https://www.codereviewhub.com/GRIDAPPSD/Bootstrap/pull/2?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/GRIDAPPSD/Bootstrap/pull/2?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/GRIDAPPSD/Bootstrap/pull/2'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/bootstrap/2)
<!-- Reviewable:end -->
***